### PR TITLE
  new: chore(android): add network permissions

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Required for network connections to MPD server -->
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    
     <application
         android:label="Echo MPD"
         android:name="${applicationName}"


### PR DESCRIPTION
Adds the `INTERNET` and `ACCESS_NETWORK_STATE` permissions to the Android manifest. These are required for the application to connect to the MPD server over the network.